### PR TITLE
Add support for objects implementing multiple interfaces

### DIFF
--- a/src/common.zig
+++ b/src/common.zig
@@ -12,10 +12,12 @@ pub const SignalHandler = struct {
 };
 
 pub const InterfaceWrapper = struct {
+    pub const DispatchResult = enum { unhandled, dispatched };
+
     instance: *anyopaque,
-    dispatch: *const fn (wrapper: *const InterfaceWrapper, conn: *Connection, msg: core.Message) anyerror!void,
+    dispatch: *const fn (wrapper: *const InterfaceWrapper, conn: *Connection, msg: core.Message) anyerror!DispatchResult,
     destroy: *const fn (wrapper: *const InterfaceWrapper, allocator: std.mem.Allocator) void,
     interface_name: [:0]const u8,
     path: [:0]const u8,
-    intro_xml: [:0]const u8,
+    intro_xml: []const u8,
 };

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -7,6 +7,7 @@ const dispatcher = @import("dispatcher.zig");
 const xml_generator = @import("xml_generator.zig");
 const Value = core.value.Value;
 const GStr = core.value.GStr;
+const GVariant = core.value.GVariant;
 const DBusWriter = core.value.DBusWriter;
 
 /// Specifies the type of D-Bus connection.
@@ -395,25 +396,63 @@ pub const Connection = struct {
 
                 if (path) |p| {
                     var handled = false;
+                    var intro_interfaces: std.ArrayList(u8) = .empty;
+                    defer intro_interfaces.deinit(self.__allocator);
+
                     for (self.registered_interfaces.items) |*w| {
                         // Check path first
                         if (std.mem.eql(u8, w.path, p)) {
                             // Then check interface or Introspectable
                             if (iface) |i| {
-                                if (std.mem.eql(u8, w.interface_name, i) or
-                                    std.mem.eql(u8, i, "org.freedesktop.DBus.Introspectable") or
+                                if (std.mem.eql(u8, i, "org.freedesktop.DBus.Introspectable") and
+                                    member != null and std.mem.eql(u8, member.?, "Introspect"))
+                                {
+                                    // Introspection needs a little special handling, because there may be multiple
+                                    // interfaces implemented by the object, and we have to return all of them.
+
+                                    if (intro_interfaces.items.len == 0)
+                                        // Begin the XML if this is the first interface
+                                        try intro_interfaces.appendSlice(self.__allocator, xml_generator.xml_prelude);
+
+                                    try intro_interfaces.appendSlice(self.__allocator, w.intro_xml);
+                                } else if (std.mem.eql(u8, w.interface_name, i) or
                                     std.mem.eql(u8, i, "org.freedesktop.DBus.Properties"))
                                 {
                                     // Dispatch
-                                    try w.dispatch(w, self, msg);
-                                    handled = true;
+                                    const dispatch_result = try w.dispatch(w, self, msg);
+                                    handled = dispatch_result == .dispatched;
                                 }
                             } else {
                                 // Fallback dispatch
-                                try w.dispatch(w, self, msg);
-                                handled = true;
+                                const dispatch_result = try w.dispatch(w, self, msg);
+                                handled = dispatch_result == .dispatched;
                             }
                         }
+                    }
+
+                    // Handle static introspection
+                    if (intro_interfaces.items.len != 0) {
+                        // Wrap up the XML
+                        try intro_interfaces.appendSlice(self.__allocator, xml_generator.xml_postlude);
+                        const xml = try intro_interfaces.toOwnedSliceSentinel(self.__allocator, 0);
+
+                        var encoder = try message.BodyEncoder.encode(self.__allocator, GStr.new(xml));
+                        defer encoder.deinit();
+                        try self.sendReply(msg, encoder);
+                        handled = true;
+                    }
+
+                    // Handle GetAll when no interfaces match
+                    if (!handled and
+                        iface != null and std.mem.eql(u8, iface.?, "org.freedesktop.DBus.Properties") and
+                        member != null and std.mem.eql(u8, member.?, "GetAll"))
+                    {
+                        var dict = std.StringHashMap(GVariant).init(self.__allocator);
+                        defer dict.deinit();
+                        var encoder = try message.BodyEncoder.encode(self.__allocator, dict);
+                        defer encoder.deinit();
+                        try self.sendReply(msg, encoder);
+                        handled = true;
                     }
 
                     // Dynamic Introspection logic

--- a/src/dispatcher.zig
+++ b/src/dispatcher.zig
@@ -6,10 +6,11 @@ const Connection = @import("connection.zig").Connection;
 const Value = core.value.Value;
 const GStr = core.value.GStr;
 const dbusAlignOf = core.value.dbusAlignOf;
+const DispatchResult = common.InterfaceWrapper.DispatchResult;
 
-pub fn getDispatchFn(comptime T: type) fn (*const common.InterfaceWrapper, *Connection, core.Message) anyerror!void {
+pub fn getDispatchFn(comptime T: type) fn (*const common.InterfaceWrapper, *Connection, core.Message) anyerror!DispatchResult {
     return struct {
-        fn dispatch(w: *const common.InterfaceWrapper, conn: *Connection, msg: core.Message) anyerror!void {
+        fn dispatch(w: *const common.InterfaceWrapper, conn: *Connection, msg: core.Message) anyerror!DispatchResult {
             const self_obj = @as(*T, @ptrCast(@alignCast(w.instance)));
 
             var member_name: ?[]const u8 = null;
@@ -21,7 +22,7 @@ pub fn getDispatchFn(comptime T: type) fn (*const common.InterfaceWrapper, *Conn
                     else => {},
                 }
             }
-            const member = member_name orelse return;
+            const member = member_name orelse return .unhandled;
 
             // PropUnion Generation
             const PropUnion = blk: {
@@ -73,7 +74,7 @@ pub fn getDispatchFn(comptime T: type) fn (*const common.InterfaceWrapper, *Conn
                     var decoder = message.BodyDecoder.fromMessage(conn.__allocator, msg);
                     const requested_iface = decoder.decode(GStr) catch {
                         try conn.sendError(msg, "org.freedesktop.DBus.Error.InvalidArgs", "Invalid interface argument");
-                        return;
+                        return .dispatched;
                     };
                     if (std.mem.eql(u8, requested_iface.s, w.interface_name)) {
                         const VariantType = Value.Variant(PropUnion);
@@ -103,24 +104,20 @@ pub fn getDispatchFn(comptime T: type) fn (*const common.InterfaceWrapper, *Conn
                         var encoder = try message.BodyEncoder.encode(conn.__allocator, dict);
                         defer encoder.deinit();
                         try conn.sendReply(msg, encoder);
+
+                        return .dispatched; // to this interface
                     } else {
-                        const VariantType = Value.Variant(PropUnion);
-                        var dict = std.StringHashMap(VariantType).init(conn.__allocator);
-                        defer dict.deinit();
-                        var encoder = try message.BodyEncoder.encode(conn.__allocator, dict);
-                        defer encoder.deinit();
-                        try conn.sendReply(msg, encoder);
+                        return .unhandled; // not this interface
                     }
-                    return;
                 } else if (std.mem.eql(u8, member, "Get")) {
                     var decoder = message.BodyDecoder.fromMessage(conn.__allocator, msg);
                     const requested_iface = decoder.decode(GStr) catch {
                         try conn.sendError(msg, "org.freedesktop.DBus.Error.InvalidArgs", "Invalid interface argument");
-                        return;
+                        return .dispatched;
                     };
                     const prop_name = decoder.decode(GStr) catch {
                         try conn.sendError(msg, "org.freedesktop.DBus.Error.InvalidArgs", "Invalid property name argument");
-                        return;
+                        return .dispatched;
                     };
 
                     if (std.mem.eql(u8, requested_iface.s, w.interface_name)) {
@@ -158,21 +155,24 @@ pub fn getDispatchFn(comptime T: type) fn (*const common.InterfaceWrapper, *Conn
                             defer encoder.deinit();
                             try conn.sendReply(msg, encoder);
                         }
+
+                        return .dispatched; // to this interface
                     }
-                    return;
+
+                    return .unhandled; // not this interface
                 } else if (std.mem.eql(u8, member, "Set")) {
                     var decoder = message.BodyDecoder.fromMessage(conn.__allocator, msg);
                     const requested_iface = decoder.decode(GStr) catch {
                         try conn.sendError(msg, "org.freedesktop.DBus.Error.InvalidArgs", "Invalid interface argument");
-                        return;
+                        return .dispatched;
                     };
                     const prop_name = decoder.decode(GStr) catch {
                         try conn.sendError(msg, "org.freedesktop.DBus.Error.InvalidArgs", "Invalid property name argument");
-                        return;
+                        return .dispatched;
                     };
                     const val_union = decoder.decode(PropUnion) catch {
                         try conn.sendError(msg, "org.freedesktop.DBus.Error.InvalidSignature", "Property value signature mismatch");
-                        return;
+                        return .dispatched;
                     };
 
                     if (std.mem.eql(u8, requested_iface.s, w.interface_name)) {
@@ -246,19 +246,11 @@ pub fn getDispatchFn(comptime T: type) fn (*const common.InterfaceWrapper, *Conn
                             defer encoder.deinit();
                             try conn.sendReply(msg, encoder);
                         }
-                    }
-                    return;
-                }
-            }
 
-            // Handle Introspect
-            if (iface_name) |iface| {
-                if (std.mem.eql(u8, iface, "org.freedesktop.DBus.Introspectable") and std.mem.eql(u8, member, "Introspect")) {
-                    // Return XML
-                    var encoder = try message.BodyEncoder.encode(conn.__allocator, GStr.new(w.intro_xml));
-                    defer encoder.deinit();
-                    try conn.sendReply(msg, encoder);
-                    return;
+                        return .dispatched; // to this interface
+                    }
+
+                    return .unhandled; // not this interface
                 }
             }
 
@@ -285,12 +277,14 @@ pub fn getDispatchFn(comptime T: type) fn (*const common.InterfaceWrapper, *Conn
                                 var encoder = try message.BodyEncoder.encode(conn.__allocator, result);
                                 defer encoder.deinit();
                                 try conn.sendReply(msg, encoder);
-                                return;
+                                return .dispatched;
                             }
                         }
                     }
                 }
             }
+
+            return .unhandled;
         }
     }.dispatch;
 }

--- a/src/xml_generator.zig
+++ b/src/xml_generator.zig
@@ -2,14 +2,46 @@ const std = @import("std");
 const core = @import("core.zig");
 const Value = core.value.Value;
 
+pub const xml_prelude =
+    \\<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+    \\ "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+    \\<node>
+;
+// .. Introspection XML for actual interfaces gets sandwiched inbetween these two fragments ..
+pub const xml_postlude =
+    \\  <interface name="org.freedesktop.DBus.Introspectable">
+    \\    <method name="Introspect">
+    \\      <arg name="xml_data" type="s" direction="out"/>
+    \\    </method>
+    \\  </interface>
+    \\  <interface name="org.freedesktop.DBus.Properties">
+    \\    <method name="Get">
+    \\      <arg name="interface_name" type="s" direction="in"/>
+    \\      <arg name="property_name" type="s" direction="in"/>
+    \\      <arg name="value" type="v" direction="out"/>
+    \\    </method>
+    \\    <method name="Set">
+    \\      <arg name="interface_name" type="s" direction="in"/>
+    \\      <arg name="property_name" type="s" direction="in"/>
+    \\      <arg name="value" type="v" direction="in"/>
+    \\    </method>
+    \\    <method name="GetAll">
+    \\      <arg name="interface_name" type="s" direction="in"/>
+    \\      <arg name="props" type="a{sv}" direction="out"/>
+    \\    </method>
+    \\    <signal name="PropertiesChanged">
+    \\      <arg name="interface_name" type="s"/>
+    \\      <arg name="changed_properties" type="a{sv}"/>
+    \\      <arg name="invalidated_properties" type="as"/>
+    \\    </signal>
+    \\  </interface>
+    \\</node>
+;
+
 /// Generates a D-Bus introspection XML string for a Zig type T.
-pub fn generateIntrospectionXml(allocator: std.mem.Allocator, comptime T: type, interface_name: []const u8) ![:0]const u8 {
+pub fn generateIntrospectionXml(allocator: std.mem.Allocator, comptime T: type, interface_name: []const u8) ![]const u8 {
     var out = try std.ArrayList(u8).initCapacity(allocator, 1024);
     errdefer out.deinit(allocator);
-
-    try out.appendSlice(allocator, "<!DOCTYPE node PUBLIC \"-//freedesktop//DTD D-BUS Object Introspection 1.0//EN\"");
-    try out.appendSlice(allocator, " \"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd\">\n");
-    try out.appendSlice(allocator, "<node>\n");
 
     try out.print(allocator, "  <interface name=\"{s}\">\n", .{interface_name});
 
@@ -92,36 +124,8 @@ pub fn generateIntrospectionXml(allocator: std.mem.Allocator, comptime T: type, 
     }
 
     try out.appendSlice(allocator, "  </interface>\n");
-    try out.appendSlice(allocator, "  <interface name=\"org.freedesktop.DBus.Introspectable\">\n");
-    try out.appendSlice(allocator, "    <method name=\"Introspect\">\n");
-    try out.appendSlice(allocator, "      <arg name=\"xml_data\" type=\"s\" direction=\"out\"/>\n");
-    try out.appendSlice(allocator, "    </method>\n");
-    try out.appendSlice(allocator, "  </interface>\n");
 
-    try out.appendSlice(allocator, "  <interface name=\"org.freedesktop.DBus.Properties\">\n");
-    try out.appendSlice(allocator, "    <method name=\"Get\">\n");
-    try out.appendSlice(allocator, "      <arg name=\"interface_name\" type=\"s\" direction=\"in\"/>\n");
-    try out.appendSlice(allocator, "      <arg name=\"property_name\" type=\"s\" direction=\"in\"/>\n");
-    try out.appendSlice(allocator, "      <arg name=\"value\" type=\"v\" direction=\"out\"/>\n");
-    try out.appendSlice(allocator, "    </method>\n");
-    try out.appendSlice(allocator, "    <method name=\"Set\">\n");
-    try out.appendSlice(allocator, "      <arg name=\"interface_name\" type=\"s\" direction=\"in\"/>\n");
-    try out.appendSlice(allocator, "      <arg name=\"property_name\" type=\"s\" direction=\"in\"/>\n");
-    try out.appendSlice(allocator, "      <arg name=\"value\" type=\"v\" direction=\"in\"/>\n");
-    try out.appendSlice(allocator, "    </method>\n");
-    try out.appendSlice(allocator, "    <method name=\"GetAll\">\n");
-    try out.appendSlice(allocator, "      <arg name=\"interface_name\" type=\"s\" direction=\"in\"/>\n");
-    try out.appendSlice(allocator, "      <arg name=\"props\" type=\"a{sv}\" direction=\"out\"/>\n");
-    try out.appendSlice(allocator, "    </method>\n");
-    try out.appendSlice(allocator, "    <signal name=\"PropertiesChanged\">\n");
-    try out.appendSlice(allocator, "      <arg name=\"interface_name\" type=\"s\"/>\n");
-    try out.appendSlice(allocator, "      <arg name=\"changed_properties\" type=\"a{sv}\"/>\n");
-    try out.appendSlice(allocator, "      <arg name=\"invalidated_properties\" type=\"as\"/>\n");
-    try out.appendSlice(allocator, "    </signal>\n");
-    try out.appendSlice(allocator, "  </interface>\n");
-    try out.appendSlice(allocator, "</node>\n");
-
-    return try out.toOwnedSliceSentinel(allocator, 0);
+    return try out.toOwnedSlice(allocator);
 }
 
 fn getSignature(allocator: std.mem.Allocator, comptime T: type) ![:0]const u8 {


### PR DESCRIPTION
Closes #10

This requires rewiring the dispatching code in `waitForObject` to stop it from early-exiting, instead letting it dispatch to more than one interface; namely:

- org.freedesktop.DBus.Introspectable.Introspect - now has to return the XML of all interfaces registered that can handle the request. I made it so that each interface emits a smaller XML fragment containing only a single `<interface>` tag, all of which are then concatenated by `Connection.waitOnHandle` which handles the dispatching logic otherwise.
- org.freedesktop.DBus.Properties - all the methods needed some rewiring such that `dispatch` would be able to tell the connection whether it has handled the request or whether a different interface needs to handle it.

---

There are probably some stylistic choices you might disagree with, I'll point them out in the comments and you can decide whether you want them in the codebase or not.